### PR TITLE
Add SectionOptions method to return options only in a section.

### DIFF
--- a/config/option.go
+++ b/config/option.go
@@ -86,3 +86,21 @@ func (self *Config) Options(section string) (options []string, err error) {
 
 	return options, nil
 }
+
+// SectionOptions returns only the list of options available in the given section.
+// Unlike Options, SectionOptions doesn't return options in default section.
+// It returns an error if the section doesn't exist.
+func (self *Config) SectionOptions(section string) (options []string, err error) {
+	if _, ok := self.data[section]; !ok {
+		return nil, errors.New(sectionError(section).Error())
+	}
+
+	options = make([]string, len(self.data[section]))
+	i := 0
+	for s, _ := range self.data[section] {
+		options[i] = s
+		i++
+	}
+
+	return options, nil
+}


### PR DESCRIPTION
Here is a scenario to use SectionOptions.

I have several features in my app. Each feature can have a name like "feature1". With SectionOptions, I can write config file as following.

```
[features]
feature1 = on
feature2 = off
feature3 = on
# and more...
```

In my code, I can just enumerate section "features" to find out which feature should be turned on, instead of enumerate all possible features and see whether config file contains the feature name.
