### PR TITLE
strip comment up top, so that comments an be applied universally. 

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -223,7 +223,7 @@ func TestReadFile(t *testing.T) {
 	buf.WriteString("variable2=a_part_of_a_%(variable1)s_test\n")
 	buf.WriteString("[secTION-2]\n")
 	buf.WriteString("IS-flag-TRUE=Yes\n")
-	buf.WriteString("[section-1]\n") // continue again [section-1]
+	buf.WriteString("[section-1] # comment on section header\n") // continue again [section-1]
 	buf.WriteString("option4=this_is_%(variable2)s.\n")
 	buf.WriteString("envoption1=this_uses_${GO_CONFIGFILE_TEST_ENV_VAR}_env\n")
 	buf.WriteString("optionInDefaultSection=false\n")

--- a/read.go
+++ b/read.go
@@ -66,7 +66,7 @@ func (c *Config) read(buf *bufio.Reader) (err error) {
 			return err
 		}
 
-		l = strings.TrimSpace(l)
+		l = strings.TrimSpace(stripComments(l))
 
 		// Switch written for readability (not performance)
 		switch {
@@ -97,12 +97,12 @@ func (c *Config) read(buf *bufio.Reader) (err error) {
 			case i > 0:
 				i := strings.IndexAny(l, "=:")
 				option = strings.TrimSpace(l[0:i])
-				value := strings.TrimSpace(stripComments(l[i+1:]))
+				value := strings.TrimSpace(l[i+1:])
 				c.AddOption(section, option, value)
 			// Continuation of multi-line value
 			case section != "" && option != "":
 				prev, _ := c.RawString(section, option)
-				value := strings.TrimSpace(stripComments(l))
+				value := strings.TrimSpace(l)
 				c.AddOption(section, option, prev+"\n"+value)
 
 			default:


### PR DESCRIPTION
Without this, section headers cannot have comments, e.g.:
[section] # comment
option: value
