### PR TITLE
Remove "rem" comment syntax

### DIFF
--- a/read.go
+++ b/read.go
@@ -74,10 +74,6 @@ func (c *Config) read(buf *bufio.Reader) (err error) {
 		case len(l) == 0, l[0] == '#', l[0] == ';':
 			continue
 
-		// Comment (for windows users)
-		case len(l) >= 3 && strings.ToLower(l[0:3]) == "rem":
-			continue
-
 		// New section
 		case l[0] == '[' && l[len(l)-1] == ']':
 			option = "" // reset multi-line value


### PR DESCRIPTION
I could find no evidence that INI files should support the "rem" comment
syntax.  This changeset removes this syntax.  This allows option names
to begin with "rem".  For example, "remote_path=/tmp" would be parsed
as comment prior to this change.
