### PR TITLE
Adds support for empty environment variables

### DIFF
--- a/type.go
+++ b/type.go
@@ -152,7 +152,7 @@ func (c *Config) String(section string, option string) (value string, err error)
 	}
 
 	// $ environment variables
-	computedVal, err = c.computeVar(&value, envVarRegExp, 2, 1, func(varName *string) string {
+	computedVal, _ = c.computeVar(&value, envVarRegExp, 2, 1, func(varName *string) string {
 		return os.Getenv(*varName)
 	})
 	value = *computedVal


### PR DESCRIPTION
I don't want to get an error for "Option not found" when an env var is indeed set to "". As far as I can tell, the `if varVal == ""` in type.go is only relevant to `%` variables.

My use case is to set a local dev DB password to "" aka no password.
