### PR TITLE
Fix last line with no \n not being read

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -226,7 +226,7 @@ func TestReadFile(t *testing.T) {
 	buf.WriteString("[section-1]\n") // continue again [section-1]
 	buf.WriteString("option4=this_is_%(variable2)s.\n")
 	buf.WriteString("envoption1=this_uses_${GO_CONFIGFILE_TEST_ENV_VAR}_env\n")
-	buf.WriteString("optionInDefaultSection=false\n")
+	buf.WriteString("optionInDefaultSection=false")
 	buf.Flush()
 	file.Close()
 

--- a/read.go
+++ b/read.go
@@ -17,7 +17,6 @@ package config
 import (
 	"bufio"
 	"errors"
-	"io"
 	"os"
 	"strings"
 )
@@ -58,15 +57,10 @@ func ReadDefault(fname string) (*Config, error) {
 func (c *Config) read(buf *bufio.Reader) (err error) {
 	var section, option string
 
-	for {
-		l, err := buf.ReadString('\n') // parse line-by-line
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
+	scanner := bufio.NewScanner(buf)
 
-		l = strings.TrimSpace(l)
+	for scanner.Scan() {
+		l := strings.TrimSpace(scanner.Text())
 
 		// Switch written for readability (not performance)
 		switch {
@@ -106,5 +100,5 @@ func (c *Config) read(buf *bufio.Reader) (err error) {
 			}
 		}
 	}
-	return nil
+	return scanner.Err()
 }


### PR DESCRIPTION
I made a new messages.en file and had only a single line in there with no \n at the end and it was not reading the line. It through me off for a bit. Changed code to use Scanner instead
