### PR TITLE
env var err should be returned

### DIFF
--- a/type.go
+++ b/type.go
@@ -152,7 +152,7 @@ func (c *Config) String(section string, option string) (value string, err error)
 	}
 
 	// $ environment variables
-	computedVal, _ = c.computeVar(&value, envVarRegExp, 2, 1, func(varName *string) string {
+	computedVal, err = c.computeVar(&value, envVarRegExp, 2, 1, func(varName *string) string {
 		return os.Getenv(*varName)
 	})
 	value = *computedVal


### PR DESCRIPTION
Currently, if the computeVar() call rturns an err it's lost.  The actual 'return value, err' line cannot return an error ever, because the err value is tested above the computeVar() call in line 150 and would have returned already.  With this patch the env var computeVar() err is returned correctly.
