### PR TITLE
Fix issues raised by go vet

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	tmp_fn    = "testdata/__test.go"
-	source_fn = "testdata/source.cfg"
-	target_fn = "testdata/target.cfg"
+	tmpFilename    = "testdata/__test.go"
+	sourceFilename = "testdata/source.cfg"
+	targetFilename = "testdata/target.cfg"
 )
 
 func testGet(t *testing.T, c *Config, section string, option string,
@@ -200,9 +200,9 @@ func TestInMemory(t *testing.T) {
 
 // TestReadFile creates a 'tough' configuration file and test (read) parsing.
 func TestReadFile(t *testing.T) {
-	file, err := os.Create(tmp_fn)
+	file, err := os.Create(tmpFilename)
 	if err != nil {
-		t.Fatal("Test cannot run because cannot write temporary file: " + tmp_fn)
+		t.Fatal("Test cannot run because cannot write temporary file: " + tmpFilename)
 	}
 
 	err = os.Setenv("GO_CONFIGFILE_TEST_ENV_VAR", "configvalue12345")
@@ -230,7 +230,7 @@ func TestReadFile(t *testing.T) {
 	buf.Flush()
 	file.Close()
 
-	c, err := ReadDefault(tmp_fn)
+	c, err := ReadDefault(tmpFilename)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -272,10 +272,10 @@ func TestWriteReadFile(t *testing.T) {
 	cw.AddOption("Another-Section", "useHTTPS", "y")
 	cw.AddOption("Another-Section", "url", "%(base-url)s/some/path")
 
-	cw.WriteFile(tmp_fn, 0644, "Test file for test-case")
+	cw.WriteFile(tmpFilename, 0644, "Test file for test-case")
 
 	// read back file and test
-	cr, err := ReadDefault(tmp_fn)
+	cr, err := ReadDefault(tmpFilename)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -285,7 +285,7 @@ func TestWriteReadFile(t *testing.T) {
 	testGet(t, cr, "Another-Section", "useHTTPS", true)
 	testGet(t, cr, "Another-Section", "url", "https://www.example.com/some/path")
 
-	defer os.Remove(tmp_fn)
+	defer os.Remove(tmpFilename)
 }
 
 // TestSectionOptions tests read options in a section without default options.
@@ -304,10 +304,10 @@ func TestSectionOptions(t *testing.T) {
 	cw.AddOption("Another-Section", "useHTTPS", "y")
 	cw.AddOption("Another-Section", "url", "%(base-url)s/some/path")
 
-	cw.WriteFile(tmp_fn, 0644, "Test file for test-case")
+	cw.WriteFile(tmpFilename, 0644, "Test file for test-case")
 
 	// read back file and test
-	cr, err := ReadDefault(tmp_fn)
+	cr, err := ReadDefault(tmpFilename)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -357,19 +357,19 @@ func TestSectionOptions(t *testing.T) {
 		t.Fatalf("SectionOptions reads wrong data: %v", options)
 	}
 
-	defer os.Remove(tmp_fn)
+	defer os.Remove(tmpFilename)
 }
 
 // TestMerge tests merging 2 configurations.
 func TestMerge(t *testing.T) {
-	target, error := ReadDefault(target_fn)
+	target, error := ReadDefault(targetFilename)
 	if error != nil {
-		t.Fatalf("Unable to read target config file '%s'", target_fn)
+		t.Fatalf("Unable to read target config file '%s'", targetFilename)
 	}
 
-	source, error := ReadDefault(source_fn)
+	source, error := ReadDefault(sourceFilename)
 	if error != nil {
-		t.Fatalf("Unable to read source config file '%s'", source_fn)
+		t.Fatalf("Unable to read source config file '%s'", sourceFilename)
 	}
 
 	target.Merge(source)

--- a/all_test.go
+++ b/all_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	tmp    = "testdata/__test.go"
-	source = "testdata/source.cfg"
-	target = "testdata/target.cfg"
+	tmp_fn    = "testdata/__test.go"
+	source_fn = "testdata/source.cfg"
+	target_fn = "testdata/target.cfg"
 )
 
 func testGet(t *testing.T, c *Config, section string, option string,
@@ -200,9 +200,9 @@ func TestInMemory(t *testing.T) {
 
 // TestReadFile creates a 'tough' configuration file and test (read) parsing.
 func TestReadFile(t *testing.T) {
-	file, err := os.Create(tmp)
+	file, err := os.Create(tmp_fn)
 	if err != nil {
-		t.Fatal("Test cannot run because cannot write temporary file: " + tmp)
+		t.Fatal("Test cannot run because cannot write temporary file: " + tmp_fn)
 	}
 
 	err = os.Setenv("GO_CONFIGFILE_TEST_ENV_VAR", "configvalue12345")
@@ -230,7 +230,7 @@ func TestReadFile(t *testing.T) {
 	buf.Flush()
 	file.Close()
 
-	c, err := ReadDefault(tmp)
+	c, err := ReadDefault(tmp_fn)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -272,10 +272,10 @@ func TestWriteReadFile(t *testing.T) {
 	cw.AddOption("Another-Section", "useHTTPS", "y")
 	cw.AddOption("Another-Section", "url", "%(base-url)s/some/path")
 
-	cw.WriteFile(tmp, 0644, "Test file for test-case")
+	cw.WriteFile(tmp_fn, 0644, "Test file for test-case")
 
 	// read back file and test
-	cr, err := ReadDefault(tmp)
+	cr, err := ReadDefault(tmp_fn)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -285,7 +285,7 @@ func TestWriteReadFile(t *testing.T) {
 	testGet(t, cr, "Another-Section", "useHTTPS", true)
 	testGet(t, cr, "Another-Section", "url", "https://www.example.com/some/path")
 
-	defer os.Remove(tmp)
+	defer os.Remove(tmp_fn)
 }
 
 // TestSectionOptions tests read options in a section without default options.
@@ -304,10 +304,10 @@ func TestSectionOptions(t *testing.T) {
 	cw.AddOption("Another-Section", "useHTTPS", "y")
 	cw.AddOption("Another-Section", "url", "%(base-url)s/some/path")
 
-	cw.WriteFile(tmp, 0644, "Test file for test-case")
+	cw.WriteFile(tmp_fn, 0644, "Test file for test-case")
 
 	// read back file and test
-	cr, err := ReadDefault(tmp)
+	cr, err := ReadDefault(tmp_fn)
 	if err != nil {
 		t.Fatalf("ReadDefault failure: %s", err)
 	}
@@ -357,19 +357,19 @@ func TestSectionOptions(t *testing.T) {
 		t.Fatalf("SectionOptions reads wrong data: %v", options)
 	}
 
-	defer os.Remove(tmp)
+	defer os.Remove(tmp_fn)
 }
 
 // TestMerge tests merging 2 configurations.
 func TestMerge(t *testing.T) {
-	target, error := ReadDefault(target)
+	target, error := ReadDefault(target_fn)
 	if error != nil {
-		t.Fatalf("Unable to read target config file '%s'", target)
+		t.Fatalf("Unable to read target config file '%s'", target_fn)
 	}
 
-	source, error := ReadDefault(source)
+	source, error := ReadDefault(source_fn)
 	if error != nil {
-		t.Fatalf("Unable to read source config file '%s'", source)
+		t.Fatalf("Unable to read source config file '%s'", source_fn)
 	}
 
 	target.Merge(source)

--- a/type.go
+++ b/type.go
@@ -51,11 +51,7 @@ func (c *Config) computeVar(beforeValue *string, regx *regexp.Regexp, headsz, ta
 		retVal := ""
 		return &retVal,
 			errors.New(
-				fmt.Sprintf(
-					"Possible cycle while unfolding variables: max depth of %d reached",
-					strconv.Itoa(_DEPTH_VALUES),
-				),
-			)
+				fmt.Sprintf("Possible cycle while unfolding variables: max depth of %d reached", _DEPTH_VALUES))
 	}
 
 	return computedVal, nil

--- a/type.go
+++ b/type.go
@@ -50,8 +50,7 @@ func (c *Config) computeVar(beforeValue *string, regx *regexp.Regexp, headsz, ta
 	if i == _DEPTH_VALUES {
 		retVal := ""
 		return &retVal,
-			errors.New(
-				fmt.Sprintf("Possible cycle while unfolding variables: max depth of %d reached", _DEPTH_VALUES))
+			fmt.Errorf("Possible cycle while unfolding variables: max depth of %d reached", _DEPTH_VALUES)
 	}
 
 	return computedVal, nil


### PR DESCRIPTION
Fixed a conflation of types between a filename and the *config.Config (source
and target).  The fmt was using a %s and meant the filename but used the nil
*config.Config

Removed an erroneous strconv.Itoa.  The fmt was using %d anyway.
